### PR TITLE
Remove Ruleset `sps-paths-no-special-characters` due to Performance Issues

### DIFF
--- a/rulesets/src/url-structure.ruleset.yml
+++ b/rulesets/src/url-structure.ruleset.yml
@@ -85,14 +85,15 @@ rules:
       functionOptions:
         match: "^(\\/|[a-z0-9-.]+|{[a-zA-Z0-9_]+})+$"
 
-  sps-paths-no-special-characters:
-    message: "A resource MUST only contain lowercase ISO basic Latin alphabet characters, the numeric characters `0-9`, and a hyphen or dash character. Parameters must be camel cased."
-    severity: error
-    given: $.paths.*~
-    then:
-      function: pattern
-      functionOptions:
-        match: ^([0-9a-z-\/]*({[a-z][0-9a-zA-Z-]+})?)*$
+  # Performance issue with spectral-cli and the regex provided - https://github.com/SPSCommerce/sps-api-standards/issues/26
+  # sps-paths-no-special-characters:
+  #  message: "A resource MUST only contain lowercase ISO basic Latin alphabet characters, the numeric characters `0-9`, and a hyphen or dash character. Parameters must be camel cased."
+  #  severity: error
+  #  given: $.paths.*~
+  #  then:
+  #    function: pattern
+  #    functionOptions:
+  #      match: ^([0-9a-z-\/]*({[a-z][0-9a-zA-Z-]+})?)*$
 
   sps-paths-trailing-slash:
     message: "A resource MUST be addressable without a trailing slash on the path."

--- a/rulesets/test/url-structure/sps-paths-no-special-characters.test.js
+++ b/rulesets/test/url-structure/sps-paths-no-special-characters.test.js
@@ -9,7 +9,7 @@ describe("sps-paths-no-special-characters", () => {
         spectral = new SpectralTestHarness(ruleset);
     });
 
-    test("succeeds with standard characters", async () => {
+    xtest("succeeds with standard characters", async () => {
         const spec = `
             openapi: 3.1.0
             paths:
@@ -21,7 +21,7 @@ describe("sps-paths-no-special-characters", () => {
         await spectral.validateSuccess(spec, ruleName);
     });
 
-    test("succeeds with interpolation", async () => {
+    xtest("succeeds with interpolation", async () => {
         const spec = `
             openapi: 3.1.0
             paths:
@@ -33,7 +33,7 @@ describe("sps-paths-no-special-characters", () => {
         await spectral.validateSuccess(spec, ruleName);
     });
 
-    test("fails special characters", async () => {
+    xtest("fails special characters", async () => {
         const spec = `
         openapi: 3.1.0
         paths:


### PR DESCRIPTION
Removing temporarily until remediation is determined so this does not block engineering teams using it.
https://github.com/SPSCommerce/sps-api-standards/issues/26