### PR TITLE
sps-request-support-json: Accuracy and Testing

### DIFF
--- a/rulesets/src/serialization.ruleset.yml
+++ b/rulesets/src/serialization.ruleset.yml
@@ -1,13 +1,19 @@
 rules:
 
   sps-request-support-json:
-    description: Every request SHOULD support `application/json` media type
+    description: Every request MUST support `application/json` media type
     formats: [oas3]
     severity: error
-    message: "{{description}}: {{error}}"
-    given: $.paths.[*].requestBody.content[?(@property.indexOf('json') === -1)]^
+    given: $.paths[*][*].requestBody.content
     then:
-      function: falsy
+      function: schema
+      functionOptions:
+        schema:
+          type: object
+          properties:
+            application/json: true
+          required:
+            - application/json
 
   sps-no-numeric-ids:
     description: Avoid exposing IDs as an integer, UUIDs or other interoperable strings are preferred.

--- a/rulesets/test/serialization/sps-request-support-json.test.js
+++ b/rulesets/test/serialization/sps-request-support-json.test.js
@@ -1,0 +1,114 @@
+const { SpectralTestHarness } = require("../harness/spectral-test-harness.js");
+
+describe("sps-request-support-json", () => {
+    let spectral = null;
+    const ruleName = "sps-request-support-json";
+    const ruleset = "src/serialization.ruleset.yml";
+
+    beforeEach(async () => {
+        spectral = new SpectralTestHarness(ruleset);
+    });
+
+    test("single application/json type successful", async () => {
+        const spec = `
+        openapi: 3.0.1
+        paths:
+          /v1/users/{id}:
+            post:
+                summary: Create User
+                requestBody:
+                    content:
+                        application/json:
+                            schema:
+                                type: object
+                                properties:
+                                    id:
+                                        type: string
+                                        description: The unique identifier for the system this user belongs to.
+                                        format: uid
+                                        example: 12345678-1234-1234-1234-123456789012
+                    required: true
+                responses:
+                    "201":
+                        description: User has been successfully created.
+        `;
+    
+        await spectral.validateSuccess(spec, ruleName);
+    });
+
+    test("no request parameters validate", async () => {
+        const spec = `
+        openapi: 3.0.1
+        paths:
+          /v1/users/{id}:
+            post:
+                summary: Create User
+                responses:
+                    "201":
+                        description: User has been successfully created.
+        `;
+    
+        await spectral.validateSuccess(spec, ruleName);
+    });
+
+    test("multiple content types works with application/json", async () => {
+        const spec = `
+        openapi: 3.0.1
+        paths:
+            /v1/users:
+                post:
+                    summary: Create User
+                    requestBody:
+                        content:
+                            multipart/form-data: 
+                                schema:
+                                    type: object
+                                    properties:
+                                        id:
+                                            type: string
+                                            description: The unique identifier for the system this user belongs to.
+                                            format: uid
+                                            example: 12345678-1234-1234-1234-123456789012
+                            application/json:
+                                schema:
+                                    type: object
+                                    properties:
+                                        id:
+                                            type: string
+                                            description: The unique identifier for the system this user belongs to.
+                                            format: uid
+                                            example: 12345678-1234-1234-1234-123456789012
+                        required: true
+                    responses:
+                        "201":
+                            description: User has been successfully created.
+        `;
+        await spectral.validateSuccess(spec, ruleName);
+    });
+
+    test("no application/json media type causses error", async () => {
+        const spec = `
+        openapi: 3.0.1
+        paths:
+            /v1/users:
+                post:
+                    summary: Create User
+                    requestBody:
+                        content:
+                            multipart/form-data: 
+                                schema:
+                                    type: object
+                                    properties:
+                                        id:
+                                            type: string
+                                            description: The unique identifier for the system this user belongs to.
+                                            format: uid
+                                            example: 12345678-1234-1234-1234-123456789012
+                        required: true
+                    responses:
+                        "201":
+                            description: User has been successfully created.
+        `;
+        await spectral.validateFailure(spec, ruleName, "Error");
+    });
+});


### PR DESCRIPTION
Original rule was enforcing that all request media types had to be application/json, where it should be one of.