### PR TITLE
Path Limit Size Rule - Closer Match to API Standards Description

### DIFF
--- a/rulesets/src/url-structure.ruleset.yml
+++ b/rulesets/src/url-structure.ruleset.yml
@@ -7,7 +7,7 @@ rules:
     then:
       function: length
       functionOptions:
-        max: 75
+        max: 150
 
   sps-hosts-https-only:
     message: "Servers MUST be https and no other protocol is allowed."

--- a/rulesets/src/url-structure.ruleset.yml
+++ b/rulesets/src/url-structure.ruleset.yml
@@ -7,7 +7,7 @@ rules:
     then:
       function: length
       functionOptions:
-        max: 150
+        max: 100
 
   sps-hosts-https-only:
     message: "Servers MUST be https and no other protocol is allowed."

--- a/rulesets/test/url-structure/sps-limit-path-size.test.js
+++ b/rulesets/test/url-structure/sps-limit-path-size.test.js
@@ -25,7 +25,7 @@ describe("sps-limit-path-size", () => {
         const spec = `
             openapi: 3.1.0
             paths: 
-                /v1/users/very/long/path/goes/here/more/than/x-characters/to-be/solong:
+                /v1/users/very/long/path/goes/here/more/than/x-characters/to-be/solong/more/than/x-characters/to-be/solong:
                     get:
                         summary: "hello-world"
         `;
@@ -37,7 +37,7 @@ describe("sps-limit-path-size", () => {
         const spec = `
             openapi: 3.1.0
             paths: 
-                /v1/users/very/long/path/goes/here/more/than/x-characters/to-be/solong/morex:
+                /v1/users/very/long/path/goes/here/more/than/x-characters/to-be/solong/morex//v1/users/very/long/path/goes/here/more/than/x-characters/to-be/solong/morex:
                     get:
                         summary: "hello-world"
         `;

--- a/rulesets/test/url-structure/sps-limit-path-size.test.js
+++ b/rulesets/test/url-structure/sps-limit-path-size.test.js
@@ -25,7 +25,7 @@ describe("sps-limit-path-size", () => {
         const spec = `
             openapi: 3.1.0
             paths: 
-                /v1/users/very/long/path/goes/here/more/than/x-characters/to-be/solong/more/than/x-characters/to-be/solong:
+                /v1/users/very/long/path/goes/here/more/than/x-characters/to-be/solong/more/than/x-characters/to-be:
                     get:
                         summary: "hello-world"
         `;
@@ -37,7 +37,7 @@ describe("sps-limit-path-size", () => {
         const spec = `
             openapi: 3.1.0
             paths: 
-                /v1/users/very/long/path/goes/here/more/than/x-characters/to-be/solong/morex//v1/users/very/long/path/goes/here/more/than/x-characters/to-be/solong/morex:
+                /v1/users/very/long/path/goes/here/more/than/x-characters/to-be/solong/morex/v1/users/very/long/path/goes/here/more:
                     get:
                         summary: "hello-world"
         `;


### PR DESCRIPTION
The description indicates the host + URL size can be "hundreds" of characters. As a result I increased this value to 100 before warning. This seems pretty long, but is more reasonably in line with the expected time to see this warning (when you do something extreme).