### PR TITLE
Standard Property Name: "fingerprint"

### DIFF
--- a/rulesets/src/naming.ruleset.yml
+++ b/rulesets/src/naming.ruleset.yml
@@ -1,0 +1,26 @@
+rules:   
+
+  sps-fingerprint-naming:
+    description: Rather than property names refering to the implementation for 'hash' or 'hashkey', you MUST use the property name 'fingerprint'.
+    message: '{{property}} is not using property name fingerprint.'
+    severity: error
+    formats: [oas3]
+    given: '$.components.schemas..properties.*~'
+    then:
+      function: pattern
+      functionOptions:
+        notMatch: '^hashkey|hashKey|hash$'
+
+  sps-fingerprint-type:
+    description: Fingerprint values MUST use a data type of `string`.
+    severity: error
+    formats: [oas3]
+    given: '$.components.schemas..properties..[?(@property=== "fingerprint")].type'
+    then:
+      function: pattern
+      functionOptions:
+        match: '^string$'
+
+
+    
+    

--- a/rulesets/test/naming/sps-fingerprint-naming.test.js
+++ b/rulesets/test/naming/sps-fingerprint-naming.test.js
@@ -1,0 +1,84 @@
+const { SpectralTestHarness } = require("../harness/spectral-test-harness.js");
+
+describe("sps-fingerprint-naming", () => {
+    let spectral = null;
+    const ruleName = "sps-fingerprint-naming";
+    const ruleset = "src/naming.ruleset.yml";
+
+    beforeEach(async () => {
+        spectral = new SpectralTestHarness(ruleset);
+    });
+
+    test("fingerprint name succeeds", async () => {
+        const spec = `
+        openapi: 3.0.1
+        paths: {}
+        components:
+            schemas:
+                User:
+                    type: object
+                    properties:
+                        id:
+                            type: string
+                        fingerprint:
+                            type: string
+                        
+        `;
+    
+        await spectral.validateSuccess(spec, ruleName);
+    });
+
+    test("hashkey usage fails", async () => {
+        const spec = `
+        openapi: 3.0.1
+        paths: {}
+        components:
+            schemas:
+                User:
+                    type: object
+                    properties:
+                        id:
+                            type: string
+                        hashkey:
+                            type: string
+                        
+        `;
+        await spectral.validateFailure(spec, ruleName, "Error");
+    });
+
+    test("hashKey (camelCase) usage fails", async () => {
+        const spec = `
+        openapi: 3.0.1
+        paths: {}
+        components:
+            schemas:
+                User:
+                    type: object
+                    properties:
+                        id:
+                            type: string
+                        hashKey:
+                            type: string
+                        
+        `;
+        await spectral.validateFailure(spec, ruleName, "Error");
+    });
+
+    test("hash usage fails", async () => {
+        const spec = `
+        openapi: 3.0.1
+        paths: {}
+        components:
+            schemas:
+                User:
+                    type: object
+                    properties:
+                        id:
+                            type: string
+                        hash:
+                            type: string
+                        
+        `;
+        await spectral.validateFailure(spec, ruleName, "Error");
+    });
+});

--- a/rulesets/test/naming/sps-fingerprint-type.test.js
+++ b/rulesets/test/naming/sps-fingerprint-type.test.js
@@ -1,0 +1,48 @@
+const { SpectralTestHarness } = require("../harness/spectral-test-harness.js");
+
+describe("sps-fingerprint-type", () => {
+    let spectral = null;
+    const ruleName = "sps-fingerprint-type";
+    const ruleset = "src/naming.ruleset.yml";
+
+    beforeEach(async () => {
+        spectral = new SpectralTestHarness(ruleset);
+    });
+
+    test("fingerprint with type string is successful", async () => {
+        const spec = `
+        openapi: 3.0.1
+        paths: {}
+        components:
+            schemas:
+                User:
+                    type: object
+                    properties:
+                        id:
+                            type: string
+                        fingerprint:
+                            type: string
+                        
+        `;
+    
+        await spectral.validateSuccess(spec, ruleName);
+    });
+
+    test("fingerprint with type number failure", async () => {
+        const spec = `
+        openapi: 3.0.1
+        paths: {}
+        components:
+            schemas:
+                User:
+                    type: object
+                    properties:
+                        id:
+                            type: string
+                        fingerprint:
+                            type: number
+                        
+        `;
+        await spectral.validateFailure(spec, ruleName, "Error");
+    });
+});

--- a/standards/naming.md
+++ b/standards/naming.md
@@ -186,6 +186,7 @@ Refer to further information in [Serialization](serialization.md) with regard to
 | modifiedDateTime   | DateTime       | The modified timestamp of an entity. |
 | modifiedBy         | String         | An identifier for a user that modified an entity. |
 | deletedBy          | String         | An identifier for a user that deleted an entity. |
+| fingerprint        | String         | Represents a hash key value derived from the contents of asset(s). |
 
 Additional standardized property names and schemas are also described in the following:
 - [Collections](collections.md)

--- a/standards/naming.md
+++ b/standards/naming.md
@@ -186,7 +186,7 @@ Refer to further information in [Serialization](serialization.md) with regard to
 | modifiedDateTime   | DateTime       | The modified timestamp of an entity. |
 | modifiedBy         | String         | An identifier for a user that modified an entity. |
 | deletedBy          | String         | An identifier for a user that deleted an entity. |
-| fingerprint        | String         | Represents a hash key value derived from the contents of asset(s). |
+| fingerprint        | String         | Represents a hash key value derived from the content of associated asset(s). |
 
 Additional standardized property names and schemas are also described in the following:
 - [Collections](collections.md)

--- a/standards/naming.md
+++ b/standards/naming.md
@@ -186,7 +186,7 @@ Refer to further information in [Serialization](serialization.md) with regard to
 | modifiedDateTime   | DateTime       | The modified timestamp of an entity. |
 | modifiedBy         | String         | An identifier for a user that modified an entity. |
 | deletedBy          | String         | An identifier for a user that deleted an entity. |
-| fingerprint        | String         | Fingerprint represents a hashed reference to an associated data context (e.g file content hash, document identifier hash, etc). Use this standardized name over something like `hashkey`. |
+| fingerprint        | String         | Fingerprint represents a hashed reference to an associated data context (e.g file content hash, document identifier hash, etc). Use this standardized name over something like `hashkey`.<a name="sps-fingerprint-naming" href="#sps-fingerprint-naming"><i class="fa fa-check-circle" title="#sps-fingerprint-naming"></i></a> |
 
 Additional standardized property names and schemas are also described in the following:
 - [Collections](collections.md)

--- a/standards/naming.md
+++ b/standards/naming.md
@@ -186,7 +186,7 @@ Refer to further information in [Serialization](serialization.md) with regard to
 | modifiedDateTime   | DateTime       | The modified timestamp of an entity. |
 | modifiedBy         | String         | An identifier for a user that modified an entity. |
 | deletedBy          | String         | An identifier for a user that deleted an entity. |
-| fingerprint        | String         | Represents a hash key value derived from the content of associated asset(s). |
+| fingerprint        | String         | Fingerprint represents a hashed reference to an associated data context (e.g file content hash, document identifier hash, etc). Use this standardized name over something like `hashkey`. |
 
 Additional standardized property names and schemas are also described in the following:
 - [Collections](collections.md)


### PR DESCRIPTION
Should use standard property name "fingerprint" over "hashkey" where applicable.

Will add "warning" linting for usage of "hashkey" has a property"... and for usage of "fingerprint" not as a "string" schema before merging.