### PR TITLE
Spectral Rule Sensitivity for Examples

### DIFF
--- a/rulesets/src/naming.ruleset.yml
+++ b/rulesets/src/naming.ruleset.yml
@@ -6,6 +6,7 @@ rules:
     severity: error
     formats: [oas3]
     given: '$..properties..[?((@property=== "ref" || @property === "Ref") && @.$ref == null && @.allOf == null && @.oneOf == null)]'
+    resolved: false
     then:
       - field: "format"
         function: truthy

--- a/rulesets/src/naming.ruleset.yml
+++ b/rulesets/src/naming.ruleset.yml
@@ -5,7 +5,7 @@ rules:
     description: Property with the name 'ref' MUST be of type 'sps-ref' following URN-like reference formats.
     severity: error
     formats: [oas3]
-    given: '$..[?((@property=== "ref" || @property === "Ref") && @.$ref == null && @.allOf == null && @.oneOf == null)]'
+    given: '$..properties..[?((@property=== "ref" || @property === "Ref") && @.$ref == null && @.allOf == null && @.oneOf == null)]'
     then:
       - field: "format"
         function: truthy

--- a/rulesets/src/root.ruleset.yml
+++ b/rulesets/src/root.ruleset.yml
@@ -9,4 +9,4 @@ rules:
   # operation ids are essential for changelogs and other evolutions over time
   operation-operationId: error
   operation-operationId-unique: error
-  oas-valid-media-example: off # buggy with examples, problem in spectral: https://github.com/stoplightio/spectral/issues/2081
+  oas3-valid-media-example: off # buggy with examples, problem in spectral: https://github.com/stoplightio/spectral/issues/2081

--- a/rulesets/src/root.ruleset.yml
+++ b/rulesets/src/root.ruleset.yml
@@ -9,4 +9,4 @@ rules:
   # operation ids are essential for changelogs and other evolutions over time
   operation-operationId: error
   operation-operationId-unique: error
-  
+  oas-valid-media-example: off # buggy with examples, problem in spectral: https://github.com/stoplightio/spectral/issues/2081

--- a/rulesets/test/naming/sps-ref-property-name.test.js
+++ b/rulesets/test/naming/sps-ref-property-name.test.js
@@ -9,7 +9,7 @@ describe("sps-ref-property-name", () => {
         spectral = new SpectralTestHarness(ruleset);
     });
 
-    test("Ref property successful with proper format", async () => {
+    test("Ref property successful with proper format and example", async () => {
         const spec = `
         openapi: 3.0.1
         paths: {}
@@ -23,6 +23,9 @@ describe("sps-ref-property-name", () => {
                             format: sps-ref
                         value:
                             type: string
+                    example:
+                        ref: myrefvalue
+                        name: hello
         `;
     
         await spectral.validateSuccess(spec, ruleName);


### PR DESCRIPTION
Specifically needed to udpate 2 rules causing issues:

oas3-valid-media-example - causing issues in very weird circumstances with examples that shouldn't be failing. But in spectral? https://github.com/stoplightio/spectral/issues/2081

Custom rule sps-ref-property-name - causing issues in indicating examples needed to use format.