### PR TITLE
Webhook Receiver / Consumer Standards & Rule

### DIFF
--- a/rulesets/src/.spectral.yml
+++ b/rulesets/src/.spectral.yml
@@ -12,3 +12,18 @@ extends:
 rules:
   #  not keeping this, just off for testing in this repo
   oas3-unused-component: off
+
+# Note: Duplicated here for testing from the "root.ruleset.yml" since overrides do not inherit
+overrides:
+  - files:
+      - "**#/paths/~1_webhooks"
+    rules:
+      sps-request-support-json: off
+      sps-schema-names-pascal-case: off
+      sps-paths-params-camel-case: off
+      sps-query-params-not-required: off
+      sps-headers-hyphenated-pascal-case: off
+      sps-no-x-headers: off
+      sps-paths-kebab-case: off
+      
+      

--- a/rulesets/src/.spectral.yml
+++ b/rulesets/src/.spectral.yml
@@ -7,6 +7,7 @@ extends:
   - request-response.ruleset.yml
   - serialization.ruleset.yml
   - url-structure.ruleset.yml 
+  - webhooks.ruleset.yml
 
 rules:
   #  not keeping this, just off for testing in this repo

--- a/rulesets/src/root.ruleset.yml
+++ b/rulesets/src/root.ruleset.yml
@@ -13,17 +13,25 @@ rules:
   # buggy with examples, problem in spectral: https://github.com/stoplightio/spectral/issues/2081
   oas3-valid-media-example: off 
 
+# NOTE: this is copied to ".spectral.yml" as well for testing locally (this is the version that is deployed)
 overrides:
   # disable linting validation for all webhooks, since we are at the mercy of the webhook provider
   # overrides do not inherit through "extends", so only directly using the SPS ruleset do these override apply
   # https://meta.stoplight.io/docs/spectral/branches/develop/293426e270fac-overrides
   - files:
-      - "**#/paths/**~1_webhooks~1**"
+      # NOTE: after paths, you cannot use "**" wildcard as a prefix... :(
+      # But everything after is automatically a wildcard (just not before)
+      - "**#/paths/~1_webhooks"
+      - "**#/paths/~1v1~1_webhooks"
+      - "**#/paths/~1v2~1_webhooks"
+      - "**#/paths/~1v3~1_webhooks"
     rules:
-      sps-request-support-json: "off"
-      sps-schema-names-pascal-case: "off"
-      sps-paths-params-camel-case: "off"
-      sps-query-params-not-required: "off"
-      sps-no-x-headers: "off"
+      sps-request-support-json: off
+      sps-schema-names-pascal-case: off
+      sps-paths-params-camel-case: off
+      sps-query-params-not-required: off
+      sps-headers-hyphenated-pascal-case: off
+      sps-no-x-headers: off
+      sps-paths-kebab-case: off
   
   

--- a/rulesets/src/root.ruleset.yml
+++ b/rulesets/src/root.ruleset.yml
@@ -22,5 +22,8 @@ overrides:
     rules:
       sps-request-support-json: "off"
       sps-schema-names-pascal-case: "off"
+      sps-paths-params-camel-case: "off"
+      sps-query-params-not-required: "off"
+      sps-no-x-headers: "off"
   
   

--- a/rulesets/src/root.ruleset.yml
+++ b/rulesets/src/root.ruleset.yml
@@ -9,4 +9,14 @@ rules:
   # operation ids are essential for changelogs and other evolutions over time
   operation-operationId: error
   operation-operationId-unique: error
+
+overrides:
+  # disable linting validation for all webhooks, since we are at the mercy of the webhook provider
+  # overrides do not inherit through "extends", so only directly using the SPS ruleset do these override apply
+  # https://meta.stoplight.io/docs/spectral/branches/develop/293426e270fac-overrides
+  - files:
+      - "**#/paths/**~1_webhooks~1**"
+    rules:
+      sps-request-support-json: "off"
+      sps-schema-names-pascal-case: "off"
   

--- a/rulesets/src/url-structure.ruleset.yml
+++ b/rulesets/src/url-structure.ruleset.yml
@@ -79,8 +79,8 @@ rules:
   sps-paths-kebab-case:
     message: "A resource containing multiple words MUST be separated using kebab-case (lower case and separated with hyphens)."
     severity: error
-    given: $.paths.*~
-    then:
+    given: $.paths[?(/^((?!_webhooks).)*$/i.test(@property))]~
+    then: 
       function: pattern
       functionOptions:
         match: "^(\\/|[a-z0-9-.]+|{[a-zA-Z0-9_]+})+$"

--- a/rulesets/src/webhooks.ruleset.yml
+++ b/rulesets/src/webhooks.ruleset.yml
@@ -1,0 +1,32 @@
+rules:
+
+  sps-webhooks-internal:
+    description: "Webhooks MUST be marked as internal using 'x-internal: true'."
+    formats: [oas3]
+    severity: error
+    given: $.paths[?(/^.*\/_webhooks\/.*$/i.test(@property))].*
+    then:
+      field: x-internal
+      function: truthy
+
+  sps-webhooks-post:
+    description: Webhooks SHOULD be POST requests.
+    formats: [oas3]
+    severity: warn
+    given: $.paths[?(/^.*\/_webhooks\/.*$/i.test(@property))].*~
+    then:
+      function: pattern
+      functionOptions:
+        match: "^post$"
+
+  sps-webhooks-path:
+    description: Webhook endpoints should be under the the path '/_webhooks/' to be identified as internal usage only.
+    formats: [oas3]
+    severity: error
+    given: $.paths[?(/^.*webhook.*$/i.test(@property))]~
+    then:
+      function: pattern
+      functionOptions:
+        match: "^.*\/_webhooks\/.*$"
+    
+      

--- a/rulesets/src/webhooks.ruleset.yml
+++ b/rulesets/src/webhooks.ruleset.yml
@@ -27,6 +27,6 @@ rules:
     then:
       function: pattern
       functionOptions:
-        match: "^.*\/_webhooks\/.*$"
+        match: ^.*\/_webhooks\/.*$
     
       

--- a/rulesets/test/root.openapi.yml
+++ b/rulesets/test/root.openapi.yml
@@ -16,6 +16,7 @@ security:
 - MyBearer: []
 tags:
 - name: Users
+- name: Webhooks
 paths:
   /v1/users:
     get:
@@ -347,6 +348,49 @@ paths:
                 requestId: b6d9a290-9f20-465b-bcd3-4a5166eeb3d7
                 detail: Requested resource 'resource/23' not found.
                 instance: https://example.com/account/12345/resource/23
+        "500":
+          description: Internal Server Error
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Error'
+              example:
+                title: Internal Server Error
+                status: 500
+                requestId: b6d9a290-9f20-465b-bcd3-4a5166eeb3d7
+                detail: Request for resource failed unexpectedly.
+                instance: https://example.com/account/12345/resource/23
+                context:
+                - code: CONNECTION_TIMEOUT
+                  message: A downstream dependency connection timed out.
+
+  /v1/_webhooks/sendgrid/email-opened:
+    post:
+      tags:
+      - Webhooks
+      summary: Sendgrid Push Notification on Email Open
+      x-internal: true
+      description: Event payload with email and open details.
+      operationId: sendgrid-email-opened
+      parameters:
+        - name: username
+          in: query
+          required: true   # requring this would normal fail, but should pass because this is a _webhook exception
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/User'
+        required: true
+      responses:
+        "204":
+          description: Item was successfully updated.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
         "500":
           description: Internal Server Error
           content:

--- a/rulesets/test/root.openapi.yml
+++ b/rulesets/test/root.openapi.yml
@@ -364,7 +364,7 @@ paths:
                 - code: CONNECTION_TIMEOUT
                   message: A downstream dependency connection timed out.
 
-  /v1/_webhooks/sendgrid/email-opened:
+  /_webhooks/sendgrid/email-opened:
     post:
       tags:
       - Webhooks
@@ -378,35 +378,11 @@ paths:
           required: true   # requring this would normal fail, but should pass because this is a _webhook exception
           schema:
             type: string
-      requestBody:
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/User'
-        required: true
       responses:
         "204":
           description: Item was successfully updated.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/User'
-        "500":
-          description: Internal Server Error
-          content:
-            application/problem+json:
-              schema:
-                $ref: '#/components/schemas/Error'
-              example:
-                title: Internal Server Error
-                status: 500
-                requestId: b6d9a290-9f20-465b-bcd3-4a5166eeb3d7
-                detail: Request for resource failed unexpectedly.
-                instance: https://example.com/account/12345/resource/23
-                context:
-                - code: CONNECTION_TIMEOUT
-                  message: A downstream dependency connection timed out.
-components:
+
+components:   
   schemas:
     PagingOffset:
       type: object

--- a/rulesets/test/url-structure/sps-paths-kebab-case.test.js
+++ b/rulesets/test/url-structure/sps-paths-kebab-case.test.js
@@ -21,6 +21,18 @@ describe("sps-paths-kebab-case", () => {
         await spectral.validateSuccess(spec, ruleName);
     });
 
+    test("succeeds with special _webhooks case", async () => {
+        const spec = `
+            openapi: 3.1.0
+            paths:
+                /v1/_webhooks/fancy:
+                    get:
+                        summary: hello
+        `;
+       
+        await spectral.validateSuccess(spec, ruleName);
+    });
+
     test("fails with camel case", async () => {
         const spec = `
             openapi: 3.1.0

--- a/rulesets/test/webhooks/sps-webhooks-internal.test.js
+++ b/rulesets/test/webhooks/sps-webhooks-internal.test.js
@@ -1,0 +1,61 @@
+const { SpectralTestHarness } = require("../harness/spectral-test-harness.js");
+
+describe("sps-webhooks-internal", () => {
+    let spectral = null;
+    const ruleName = "sps-webhooks-internal";
+    const ruleset = "src/webhooks.ruleset.yml";
+
+    beforeEach(async () => {
+        spectral = new SpectralTestHarness(ruleset);
+    });
+
+    test("regular paths are not triggering this warning", async () => {
+        const spec = `
+            openapi: 3.1.0
+            paths: 
+                /v1/producer/events:
+                    get:
+                        summary: "hello-world"
+        `;
+    
+        await spectral.validateSuccess(spec, ruleName);
+    });
+
+    test("webhook paths trigger no warning if no x-internal", async () => {
+        const spec = `
+            openapi: 3.1.0
+            paths: 
+                /v1/_webhooks/producer/events:
+                    post:
+                        x-internal: true
+                        summary: "hello-world"
+        `;
+    
+        await spectral.validateSuccess(spec, ruleName);
+    });
+
+    test("webhook paths trigger warning if no x-internal", async () => {
+        const spec = `
+            openapi: 3.1.0
+            paths: 
+                /v1/_webhooks/producer/events:
+                    post:
+                        summary: "hello-world"
+        `;
+    
+        await spectral.validateFailure(spec, ruleName, "Error", 1);
+    });
+
+    test("webhook paths trigger warning if x-internal false", async () => {
+        const spec = `
+            openapi: 3.1.0
+            paths: 
+                /v1/_webhooks/producer/events:
+                    post:
+                        x-internal: false
+                        summary: "hello-world"
+        `;
+    
+        await spectral.validateFailure(spec, ruleName, "Error", 1);
+    });
+});

--- a/rulesets/test/webhooks/sps-webhooks-path.test.js
+++ b/rulesets/test/webhooks/sps-webhooks-path.test.js
@@ -1,0 +1,83 @@
+const { SpectralTestHarness } = require("../harness/spectral-test-harness.js");
+
+describe("sps-webhooks-path", () => {
+    let spectral = null;
+    const ruleName = "sps-webhooks-path";
+    const ruleset = "src/webhooks.ruleset.yml";
+
+    beforeEach(async () => {
+        spectral = new SpectralTestHarness(ruleset);
+    });
+
+    test("regular paths are not triggering this warning", async () => {
+        const spec = `
+            openapi: 3.1.0
+            paths: 
+                /v1/producer/events:
+                    get:
+                        summary: "hello-world"
+        `;
+    
+        await spectral.validateSuccess(spec, ruleName);
+    });
+
+    test("proper _webhooks path should not trigger this", async () => {
+        const spec = `
+            openapi: 3.1.0
+            paths: 
+                /v1/_webhooks/events:
+                    get:
+                        summary: "hello-world"
+        `;
+    
+        await spectral.validateSuccess(spec, ruleName);
+    });
+
+    test("no underscore should trigger this", async () => {
+        const spec = `
+            openapi: 3.1.0
+            paths: 
+                /v1/webhooks/producer/events:
+                    get:
+                        summary: "hello-world"
+        `;
+    
+        await spectral.validateFailure(spec, ruleName, "Error", 1);
+    });
+
+    test("singular no underscore should trigger this", async () => {
+        const spec = `
+            openapi: 3.1.0
+            paths: 
+                /v1/webhook/producer/events:
+                    get:
+                        summary: "hello-world"
+        `;
+    
+        await spectral.validateFailure(spec, ruleName, "Error", 1);
+    });
+
+    test("singular should trigger this", async () => {
+        const spec = `
+            openapi: 3.1.0
+            paths: 
+                /v1/_webhook/producer/events:
+                    get:
+                        summary: "hello-world"
+        `;
+    
+        await spectral.validateFailure(spec, ruleName, "Error", 1);
+    });
+
+    test("random location in path should trigger this", async () => {
+        const spec = `
+            openapi: 3.1.0
+            paths: 
+                /v1/producer-webhook/events:
+                    get:
+                        summary: "hello-world"
+        `;
+    
+        await spectral.validateFailure(spec, ruleName, "Error", 1);
+    });
+});

--- a/rulesets/test/webhooks/sps-webhooks-post.test.js
+++ b/rulesets/test/webhooks/sps-webhooks-post.test.js
@@ -1,0 +1,83 @@
+const { SpectralTestHarness } = require("../harness/spectral-test-harness.js");
+
+describe("sps-webhooks-post", () => {
+    let spectral = null;
+    const ruleName = "sps-webhooks-post";
+    const ruleset = "src/webhooks.ruleset.yml";
+
+    beforeEach(async () => {
+        spectral = new SpectralTestHarness(ruleset);
+    });
+
+    test("regular paths are not triggering this warning", async () => {
+        const spec = `
+            openapi: 3.1.0
+            paths: 
+                /v1/producer/events:
+                    get:
+                        summary: "hello-world"
+        `;
+    
+        await spectral.validateSuccess(spec, ruleName);
+    });
+
+    test("webhook as a get request should be called out", async () => {
+        const spec = `
+            openapi: 3.1.0
+            paths: 
+                /v1/_webhooks/producer/events:
+                    get:
+                        summary: "hello-world"
+        `;
+    
+        await spectral.validateFailure(spec, ruleName, "Warning", 1);
+    });
+
+    test("webhook as a put request should be called out", async () => {
+        const spec = `
+            openapi: 3.1.0
+            paths: 
+                /v1/_webhooks/producer/events:
+                    put:
+                        summary: "hello-world"
+        `;
+    
+        await spectral.validateFailure(spec, ruleName, "Warning", 1);
+    });
+
+    test("webhook as a patch request should be called out", async () => {
+        const spec = `
+            openapi: 3.1.0
+            paths: 
+                /v1/_webhooks/producer/events:
+                    patch:
+                        summary: "hello-world"
+        `;
+    
+        await spectral.validateFailure(spec, ruleName, "Warning", 1);
+    });
+
+    test("webhook as a delete request should be called out", async () => {
+        const spec = `
+            openapi: 3.1.0
+            paths: 
+                /v1/_webhooks/producer/events:
+                    delete:
+                        summary: "hello-world"
+        `;
+    
+        await spectral.validateFailure(spec, ruleName, "Warning", 1);
+    });
+
+    test("webhook as a post rquest is fine", async () => {
+        const spec = `
+            openapi: 3.1.0
+            paths: 
+                /v1/_webhooks/producer/events:
+                    post:
+                        summary: "hello-world"
+        `;
+    
+        await spectral.validateSuccess(spec, ruleName);
+    });
+});

--- a/standards/webhooks.md
+++ b/standards/webhooks.md
@@ -1,0 +1,9 @@
+# Webhooks
+
+## Overview
+
+TODO
+
+## External Receivers
+
+TODO - not focusing on Webhook creation

--- a/standards/webhooks.md
+++ b/standards/webhooks.md
@@ -17,7 +17,7 @@ Webhook consumption is necessary to integrate with other first-party and third-p
 
 Webhook consuming endpoints:
 - **MAY NOT** follow API Standards or best practices when it does not pose inherit security risks or affect the rest of the API design consistency and experience.
-- **MUST** be marked as **internal** usage only in the design specification (i.e. in Open API Spec, this would translate to `x-internal: true`). <a name="sps-webhooks-internal" href="#sps-webhooks-internal"><i class="fa fa-check-circle" title="#sps-webhooks-internal"></i></a>
+- **MUST** be marked as **internal** usage only in the design specification. Internal usage implies that the endpoint should only be used by the API Producer themselves, including the configuration of that endpoint by them against a third party system if needed. Internal usage does not imply the endpoint is not publicly addressable (i.e. in Open API Spec, this would translate to `x-internal: true`). <a name="sps-webhooks-internal" href="#sps-webhooks-internal"><i class="fa fa-check-circle" title="#sps-webhooks-internal"></i></a>
 - **SHOULD** be `POST` endpoints unless specifically needing an alternative by the webhook producer. <a name="sps-webhooks-post" href="#sps-webhooks-post"><i class="fa fa-check-circle" title="#sps-webhooks-post"></i></a>
 - **MUST** be sent over `HTTPS` without exception.
 - **MUST** be secured with a unique secret key or token that prevents general requests to the webhook endpoint not from the webhook producer.

--- a/standards/webhooks.md
+++ b/standards/webhooks.md
@@ -2,8 +2,47 @@
 
 ## Overview
 
-TODO
+Webhooks are automated messages sent from apps when something happens, typically used to integrate two disconnected systems together, such as with a third-party provider. They have a message—or payload—and are sent to a unique URL configured by the customer or user. Webhooks are an advantage in an API as they are almost always faster than polling for an updated status or parsing to determine which events or changes are new within a timeline. 
 
-## External Receivers
+- Services **SHOULD** implement push notifications, HTTP callbacks, and other event notifications via webhooks.
+- Services **MAY** implement HTTP callback endpoints as a webhook consumer from other systems and/or APIs.
 
-TODO - not focusing on Webhook creation
+```note
+Push notification via HTTP Callbacks, often called Web Hooks, to publicly-addressable servers.
+```
+
+## Webhook Consumer
+
+Webhook consumption is necessary to integrate with other first-party and third-party systems. Often building specific API endpoints is necessary to receive webhook-specific payloads, headers and authorization in which the API producer cannot control or change. These webhook specific integration endpoints are usually not RESTful resources and may be required to deviate from expected design patterns within this API Style Guide. As a result webhook consumers should recognize this and organize webhook consuming endpoints accordingly.
+
+Webhook consuming endpoints:
+- **MAY NOT** follow API Standards or best practices when it does not pose inherit security risks or affect the rest of the API design consistency and experience.
+- **MUST** be marked as **internal** usage only in the design specification (i.e. in Open API Spec, this would translate to `x-internal: true`). <a name="sps-webhooks-internal" href="#sps-webhooks-internal"><i class="fa fa-check-circle" title="#sps-webhooks-internal"></i></a>
+- **SHOULD** be `POST` endpoints unless specifically needing an alternative by the webhook producer. <a name="sps-webhooks-post" href="#sps-webhooks-post"><i class="fa fa-check-circle" title="#sps-webhooks-post"></i></a>
+- **MUST** be sent over `HTTPS` without exception.
+- **MUST** be secured with a unique secret key or token that prevents general requests to the webhook endpoint not from the webhook producer.
+- **MUST** use a route with path prefix `/_webhooks/` to clearly identify the endpoint intention and purpose for internal usage. <a name="sps-webhooks-path" href="#sps-webhooks-path"><i class="fa fa-check-circle" title="#sps-webhooks-path"></i></a>
+- **SHOULD** indicate the webhook producer or product in the route path if the endpoint is intended for a vendor specific request only, for example `/_webhooks/product-name/` (e.g. `/_webhooks/sendgrid/`).
+- **MAY** indicate a particular type of event or purpose in the route path if needed to disambiguate between different types of webhook events coming from the same webhook producer, for example `/_webhooks/product-name/specific-event` (e.g. `/_webhooks/sendgrid/email-sent`).
+
+Example:
+```
+// CORRECT
+POST /_webhooks/sendgrid/email-sent             # variations of different events for sendgrid email SaaS offering
+POST /_webhooks/sendgrid/email-opened
+POST /_webhooks/sendgrid/email-clicked
+POST /_webhooks/email-event                     # a more generic event that might be used in more confiurable webhook producers
+                                                # where a single hook and event structure makes sense (same payload schema)
+// INCORRECT
+GET /_webhooks/sendgrid/email-sent              # should be a POST request      
+POST /_webhooks/                                # requires at least one identifier after /_webhooks/
+POST /hooks/sendgrid/email-sent                 # prefix path must be /_webhooks/
+POST /hooks/sendgrid/email_sent                 # continue to support API Standards where you can, using kebab-case in the URL.
+                                                # typically, the webhook producer must at least make the path configurable.
+```
+
+## Webhook Producer
+
+```note
+Webhook producer standards and best practices are still under development. Some relevant starting material: [Microsoft REST API Guidelines: Webhooks](https://github.com/Microsoft/api-guidelines/blob/master/Guidelines.md#14-push-notifications-via-webhooks)
+```

--- a/standards/webhooks.md
+++ b/standards/webhooks.md
@@ -2,9 +2,10 @@
 
 ## Overview
 
-Webhooks are automated messages sent from apps when something happens, typically used to integrate two disconnected systems together, such as with a third-party provider. They have a message—or payload—and are sent to a unique URL configured by the customer or user. Webhooks are an advantage in an API as they are almost always faster than polling for an updated status or parsing to determine which events or changes are new within a timeline. 
+A webhook is an HTTP-based callback function that allows lightweight, usually event-driven communication between two APIs. Webhooks are used by a wide variety of web apps to receive small amounts of data from other apps when specific events occur. This is especially useful for integration with third-party APIs. They have a message—or payload—and are sent to a unique URL configured by the consumer. Webhooks are an advantage in an API as they are almost always faster than polling for an updated status or parsing to determine which events or changes are new within a timeline. 
 
-- Services **SHOULD** implement push notifications, HTTP callbacks, and other event notifications via webhooks.
+
+- Services **MAY** implement push notifications, HTTP callbacks, and other event notifications via webhooks.
 - Services **MAY** implement HTTP callback endpoints as a webhook consumer from other systems and/or APIs.
 
 ```note
@@ -13,11 +14,11 @@ Push notification via HTTP Callbacks, often called Web Hooks, to publicly-addres
 
 ## Webhook Consumer
 
-Webhook consumption is necessary to integrate with other first-party and third-party systems. Often building specific API endpoints is necessary to receive webhook-specific payloads, headers and authorization in which the API producer cannot control or change. These webhook specific integration endpoints are usually not RESTful resources and may be required to deviate from expected design patterns within this API Style Guide. As a result webhook consumers should recognize this and organize webhook consuming endpoints accordingly.
+Webhook consumption often requires building API endpoints to receive webhook-specific request schemas, headers and authorization that is different from current API style and standards as webhook requests are owned by its producer and not the consumer. As a result webhook consumers should recognize this and organize webhook consuming endpoints accordingly.
 
 Webhook consuming endpoints:
 - **MAY NOT** follow API Standards or best practices when it does not pose inherit security risks or affect the rest of the API design consistency and experience.
-- **MUST** be marked as **internal** usage only in the design specification. Internal usage implies that the endpoint should only be used by the API Producer themselves, including the configuration of that endpoint by them against a third party system if needed. Internal usage does not imply the endpoint is not publicly addressable (i.e. in Open API Spec, this would translate to `x-internal: true`). <a name="sps-webhooks-internal" href="#sps-webhooks-internal"><i class="fa fa-check-circle" title="#sps-webhooks-internal"></i></a>
+- **MUST** be marked as **internal** usage only in the design specification. Internal usage implies that the endpoint should only be used by the API owner themselves, including the configuration of that endpoint by them against a third party system if needed. Internal usage does not imply the endpoint is not publicly addressable (i.e. in Open API Spec, this would translate to `x-internal: true`). <a name="sps-webhooks-internal" href="#sps-webhooks-internal"><i class="fa fa-check-circle" title="#sps-webhooks-internal"></i></a>
 - **SHOULD** be `POST` endpoints unless specifically needing an alternative by the webhook producer. <a name="sps-webhooks-post" href="#sps-webhooks-post"><i class="fa fa-check-circle" title="#sps-webhooks-post"></i></a>
 - **MUST** be sent over `HTTPS` without exception.
 - **MUST** be secured with a unique secret key or token that prevents general requests to the webhook endpoint not from the webhook producer.
@@ -31,8 +32,11 @@ Example:
 POST /_webhooks/sendgrid/email-sent             # variations of different events for sendgrid email SaaS offering
 POST /_webhooks/sendgrid/email-opened
 POST /_webhooks/sendgrid/email-clicked
+POST /_webhooks/sendgrid                        # some webhoosk producers may want a single endpoint to send all events too
+                                                # the request payload typically would indicate the event type
 POST /_webhooks/email-event                     # a more generic event that might be used in more confiurable webhook producers
                                                 # where a single hook and event structure makes sense (same payload schema)
+                                    
 // INCORRECT
 GET /_webhooks/sendgrid/email-sent              # should be a POST request      
 POST /_webhooks/                                # requires at least one identifier after /_webhooks/


### PR DESCRIPTION
This is a relatively small update that incorporates patterns for how to handle non-RESTful webhook receiver endpoints that your API may implement intenrally to integrate with other systems. In many cases formatting your endpoint to these API Standards is not your choice or a reality, and so this provides automation rules on how to encapsulate and where to put these non-standard, internal only endpoints (internal meaning they are consumed by integrations configured only by the internal team).

This adds documentation, rulesets and a new "overrides" concept that prevents API Standards from executing against "webhooks" paths (as specified).