### PR TITLE
`sps-fingerprint-type` Spectral Ruleset Performance

### DIFF
--- a/rulesets/src/naming.ruleset.yml
+++ b/rulesets/src/naming.ruleset.yml
@@ -78,7 +78,7 @@ rules:
     description: Fingerprint values MUST use a data type of `string`.
     severity: error
     formats: [oas3]
-    given: '$.components.schemas..properties..[?(@property=== "fingerprint")].type'
+    given: '$..[?(@property === "fingerprint")].type'
     then:
       function: pattern
       functionOptions:


### PR DESCRIPTION
With the existing JSON Path expression this was taking minutes to resolve. It now resolves in seconds. It is also more apropriately looking for fingerprint types not just in components but everywhere.