### PR TITLE
Localhost Exceptions & Innacurate Long Resource Paths

### DIFF
--- a/rulesets/src/url-structure.ruleset.yml
+++ b/rulesets/src/url-structure.ruleset.yml
@@ -10,14 +10,14 @@ rules:
         max: 100
 
   sps-hosts-https-only:
-    message: "Servers MUST be https and no other protocol is allowed."
+    message: "Servers MUST be https and no other protocol is allowed unless using localhost."
     formats: [oas3]
     severity: error
     given: $.servers..url
     then:
       function: pattern
       functionOptions:
-        match: "/^https:/"
+        match: ^(https:|http://localhost)
 
   sps-hosts-lowercase:
     message: "Server URL SHOULD BE lowercase."
@@ -37,7 +37,7 @@ rules:
     then:
       function: pattern
       functionOptions:
-        match: api.spscommerce.com|api.sps-internal.com
+        match: api.spscommerce.com|api.sps-internal.com|localhost
   
   sps-path-no-environment:
     message: "API paths MUST NOT indicate environment names."
@@ -49,14 +49,14 @@ rules:
         notMatch: /prod/|/preprod/|/dev/|/test/|/integration/|/stage/
 
   sps-hosts-no-port:
-    message: "Port MUST NOT be specified or required to use the API."
+    message: "Port MUST NOT be specified or required to use the API, except for 'localhost' testing in a spec."
     formats: [oas3]
     severity: error
     given: $.servers..url
     then:
       function: pattern
       functionOptions:
-        notMatch: (https?://.*):(\d*)\/?(.*)  
+        notMatch: (?!https?://localhost)(https?://.*):(\d*)\/?(.*) 
 
   sps-paths-expose-technology:
     message: "A resource MUST NOT leak or expose format or technology-specific information at any point in the path."

--- a/rulesets/src/url-structure.ruleset.yml
+++ b/rulesets/src/url-structure.ruleset.yml
@@ -122,14 +122,23 @@ rules:
       functionOptions:
         notMatch: //
 
-  sps-paths-limit-sub-resources:
-    message: The hierarchy of nested resources SHOULD NOT exceed more than 3 resources
+  sps-paths-limit-path-parameters:
+    message: The URL path should not contain more than 3 dynamic path parameters.
     severity: warn
     given: $.paths.*~
     then:
       function: pattern
       functionOptions:
-        match: ^\/[^\/]*((\/{[^}]*})*\/[^\/]*(\/{[^}]*})*){0,3}\/?$
+        notMatch: ^(.*{{1}.*){4,}
+  
+  sps-paths-limit-sub-resources:
+    message: The hierarchy of nested resources SHOULD NOT contain more than 8 resource names in the path.
+    severity: warn
+    given: $.paths.*~
+    then:
+      function: pattern
+      functionOptions:
+        notMatch: ^(.*\/{1}.*){9,}
 
   sps-paths-with-http-methods:
     message: "A resource SHOULD NOT contain HTTP methods."

--- a/rulesets/test/root.openapi.yml
+++ b/rulesets/test/root.openapi.yml
@@ -8,6 +8,8 @@ externalDocs:
   description: <--External Documentation-->
   url: https://url.here
 servers:
+- url: http://localhost:5000
+  description: local
 - url: https://integration.api.spscommerce.com
   description: integration
 - url: https://api.spscommerce.com

--- a/rulesets/test/url-structure/sps-hosts-https-only.test.js
+++ b/rulesets/test/url-structure/sps-hosts-https-only.test.js
@@ -21,6 +21,30 @@ describe("sps-hosts-https-only", () => {
         await spectral.validateSuccess(spec, ruleName);
     });
 
+    test("http is ok for localhost", async () => {
+        const spec = `
+            openapi: 3.1.0
+            paths: {}
+            servers:
+                - description: test-env
+                  url: http://localhost:4000
+        `;
+       
+        await spectral.validateSuccess(spec, ruleName);
+    });
+
+    test("https is good for localhost", async () => {
+        const spec = `
+            openapi: 3.1.0
+            paths: {}
+            servers:
+                - description: test-env
+                  url: https://localhost:4000
+        `;
+       
+        await spectral.validateSuccess(spec, ruleName);
+    });
+
     test("http is no good", async () => {
         const spec = `
             openapi: 3.1.0
@@ -30,6 +54,18 @@ describe("sps-hosts-https-only", () => {
                   url: https://api.test.com
                 - description: prod-env
                   url: http://api.prod.com
+        `;
+    
+        await spectral.validateFailure(spec, ruleName, "Error");
+    });
+
+    test("http is no good for loopback", async () => {
+        const spec = `
+            openapi: 3.1.0
+            paths: {}
+            servers:
+                - description: test-env
+                  url: http://127.0.0.1:4000
         `;
     
         await spectral.validateFailure(spec, ruleName, "Error");

--- a/rulesets/test/url-structure/sps-hosts-no-port.test.js
+++ b/rulesets/test/url-structure/sps-hosts-no-port.test.js
@@ -19,11 +19,41 @@ describe("sps-hosts-no-port", () => {
         await spectral.validateSuccess(spec, ruleName);
     });
 
+    test("succeeds with port number on localhost http", async () => {
+        const spec = `
+            openapi: 3.1.0
+            servers:
+                - url: http://localhost:3000
+        `;
+       
+        await spectral.validateSuccess(spec, ruleName);
+    });
+
+    test("succeeds with port number on localhost https", async () => {
+        const spec = `
+            openapi: 3.1.0
+            servers:
+                - url: https://localhost:3000
+        `;
+       
+        await spectral.validateSuccess(spec, ruleName);
+    });
+
     test("fails with standard port", async () => {
         const spec = `
             openapi: 3.1.0
             servers:
                 - url: https://api.spscommerce.com:443
+        `;
+       
+        await spectral.validateFailure(spec, ruleName, "Error", 1);
+    });
+
+    test("fails with local address port", async () => {
+        const spec = `
+            openapi: 3.1.0
+            servers:
+                - url: https://127.0.0.1:5000
         `;
        
         await spectral.validateFailure(spec, ruleName, "Error", 1);

--- a/rulesets/test/url-structure/sps-hosts-spscommerce-domain.test.js
+++ b/rulesets/test/url-structure/sps-hosts-spscommerce-domain.test.js
@@ -42,6 +42,51 @@ describe("sps-hosts-spscommerce-domain", () => {
         await spectral.validateSuccess(spec, ruleName);
     });
 
+    test("succeeds on localhost https", async () => {
+        const spec = `
+            openapi: 3.1.0
+            paths: {}
+            servers:
+                - url: https://localhost:4000
+        `;
+       
+        await spectral.validateSuccess(spec, ruleName);
+    });
+
+    test("succeeds on localhost http", async () => {
+        const spec = `
+            openapi: 3.1.0
+            paths: {}
+            servers:
+                - url: http://localhost:5000
+        `;
+       
+        await spectral.validateSuccess(spec, ruleName);
+    });
+
+
+    test("succeeds on network environment", async () => {
+        const spec = `
+            openapi: 3.1.0
+            paths: {}
+            servers:
+                - url: https://network.api.spscommerce.com
+        `;
+       
+        await spectral.validateSuccess(spec, ruleName);
+    });
+
+    test("succeeds on subdomain environment", async () => {
+        const spec = `
+            openapi: 3.1.0
+            paths: {}
+            servers:
+                - url: https://integration.network.api.spscommerce.com
+        `;
+       
+        await spectral.validateSuccess(spec, ruleName);
+    });
+
     test("fails with other domain", async () => {
         const spec = `
             openapi: 3.1.0

--- a/rulesets/test/url-structure/sps-paths-limit-path-parameters.test.js
+++ b/rulesets/test/url-structure/sps-paths-limit-path-parameters.test.js
@@ -1,0 +1,85 @@
+const { SpectralTestHarness } = require("../harness/spectral-test-harness.js");
+
+describe("sps-paths-limit-path-parameters", () => {
+    let spectral = null;
+    const ruleName = "sps-paths-limit-path-parameters";
+    const ruleset = "src/url-structure.ruleset.yml";
+
+    beforeEach(async () => {
+        spectral = new SpectralTestHarness(ruleset);
+    });
+
+    
+
+    test("succeeds with 3 hierarchy levels", async () => {
+        const spec = `
+            openapi: 3.1.0
+            paths:
+                /v1/users/{userId}/profiles/{profileId}/images/{imageId}:
+                    get:
+                        summary: hello
+        `;
+       
+        await spectral.validateSuccess(spec, ruleName);
+    });
+
+    test("succeeds with hierarchy and no parameters", async () => {
+        const spec = `
+            openapi: 3.1.0
+            paths:
+                /domain/v1/examples/queue/purge:
+                    get:
+                        summary: hello
+        `;
+       
+        await spectral.validateSuccess(spec, ruleName);
+    });
+
+    test("example succeeds", async () => {
+        const spec = `
+            openapi: 3.1.0
+            paths:
+                /v2/types/{id}/rules/instances/evaluate
+                    get:
+                        summary: hello
+        `;
+       
+        await spectral.validateSuccess(spec, ruleName);
+    });
+
+    test("fails after 3 hierarchy levels", async () => {
+        const spec = `
+            openapi: 3.1.0
+            paths:
+                /v1/users/{userId}/profiles/{profileId}/images/{imageId}/another-level/{anotherId}:
+                    get:
+                        summary: hello
+        `;
+       
+        await spectral.validateFailure(spec, ruleName, "Warning", 1);
+    });
+
+    test("succeeds with only 3 dynamic params", async () => {
+        const spec = `
+            openapi: 3.1.0
+            paths:
+                /v1/users/{userId}/{profileId}/{imageId}/resources:
+                    get:
+                        summary: hello
+        `;
+       
+        await spectral.validateSuccess(spec, ruleName);
+    });
+
+    test("fails with more than 3 dynamic parameters", async () => {
+        const spec = `
+            openapi: 3.1.0
+            paths:
+                /v1/users/{userId}/{profileId}/{imageId}/{anotherId}/resources:
+                    get:
+                        summary: hello
+        `;
+       
+        await spectral.validateFailure(spec, ruleName, "Warning", 1);
+    });
+});

--- a/rulesets/test/url-structure/sps-paths-limit-sub-resources.test.js
+++ b/rulesets/test/url-structure/sps-paths-limit-sub-resources.test.js
@@ -21,11 +21,24 @@ describe("sps-paths-limit-sub-resources", () => {
         await spectral.validateSuccess(spec, ruleName);
     });
 
-    test("fails after 3 hierarchy levels", async () => {
+    test("succeeds with a lot of resources", async () => {
         const spec = `
             openapi: 3.1.0
             paths:
-                /v1/users/{userId}/profiles/{profileId}/images/{imageId}/another-level:
+                /v1/this/resource/should/not/fail/queue/purge:
+                    get:
+                        summary: hello
+        `;
+       
+        await spectral.validateSuccess(spec, ruleName);
+    });
+
+    
+    test("fails after too many sub resources", async () => {
+        const spec = `
+            openapi: 3.1.0
+            paths:
+                /v1/this/resource/should/not/fail/queue/purge/failed:
                     get:
                         summary: hello
         `;


### PR DESCRIPTION
This Pull Request is pretty small, but does tackle two separate issues that can be released together.

1. Localhost Exceptions
When working with a design locally it is helpful to specify and include "localhost" in server URLs that may or may not be "https". All related rules now allow for port number and localhost with http if needed. i.e. can use: http://localhost:5000

2. Innaccurate Rule: Hierarchy Exceeding 3 Resources
This rule seems like an unruly regex, and somehow is not detecting what we wanted. This has been broken into two separate rules. The first for detecting the number of dynamic parameters in the Path (limiting that to 3 or less). The second just checks number of resources in the URL in general, failing at 9+.  https://github.com/SPSCommerce/sps-api-standards/issues/31