### PR TITLE
camelCase Query Parameters Can Use Word Group Separator 

### DIFF
--- a/rulesets/src/url-structure.ruleset.yml
+++ b/rulesets/src/url-structure.ruleset.yml
@@ -177,6 +177,9 @@ rules:
       functionOptions:
         type: camel
         disallowDigits: true
+        separator:
+          char: .
+          allowLeading: false
 
   sps-query-params-not-required:
     message: "Query parameters MUST be optional."

--- a/rulesets/test/url-structure/sps-query-params-camel-case.test.js
+++ b/rulesets/test/url-structure/sps-query-params-camel-case.test.js
@@ -68,4 +68,34 @@ describe("sps-query-params-camel-case", () => {
        
         await spectral.validateFailure(spec, ruleName, "Error", 1);
     });
+
+    test("succeeds with query parameter camelCase complex object with period", async () => {
+        const spec = `
+            openapi: 3.1.0
+            paths:
+                /v1/users:
+                    get:
+                        summary: hello
+                        parameters:
+                        - name: object.filterThing
+                          in: query
+        `;
+       
+        await spectral.validateSuccess(spec, ruleName);
+    });
+
+    test("fails with query parameter camelCase complex object with dash", async () => {
+        const spec = `
+            openapi: 3.1.0
+            paths:
+                /v1/users:
+                    get:
+                        summary: hello
+                        parameters:
+                        - name: object-filterThing
+                          in: query
+        `;
+       
+        await spectral.validateFailure(spec, ruleName, "Error", 1);
+    });
 });


### PR DESCRIPTION
For complex objects, using a period to separate camelCase properties is essential. This can be enabled easily. This resolves: https://github.com/SPSCommerce/sps-api-standards/issues/64