### PR TITLE
Bug: Fix issue with sps-paths-kebab-case that would cause lock up

### DIFF
--- a/rulesets/src/url-structure.ruleset.yml
+++ b/rulesets/src/url-structure.ruleset.yml
@@ -82,6 +82,8 @@ rules:
     given: $.paths[?(/^((?!_webhooks).)*$/i.test(@property))]~
     then: 
       function: pattern
+      # (.+_.) looks for any instance of an underscore followed by any character
+      # (\/[a-z]+[A-Z]) looks for any instance of a forward slash followed by a lowercase character followed by an uppercase character
       functionOptions:
         notMatch: (.+_.)|(\/[a-z]+[A-Z])
 

--- a/rulesets/src/url-structure.ruleset.yml
+++ b/rulesets/src/url-structure.ruleset.yml
@@ -85,7 +85,7 @@ rules:
       # (.+_.) looks for any instance of an underscore followed by any character
       # (\/[a-z]+[A-Z]) looks for any instance of a forward slash followed by a lowercase character followed by an uppercase character
       functionOptions:
-        notMatch: (.+_.)|(\/[a-z]+[A-Z])
+        notMatch: (\/[a-z]+_.)|(\/[a-z]+[A-Z])
 
   # Performance issue with spectral-cli and the regex provided - https://github.com/SPSCommerce/sps-api-standards/issues/26
   # sps-paths-no-special-characters:

--- a/rulesets/src/url-structure.ruleset.yml
+++ b/rulesets/src/url-structure.ruleset.yml
@@ -83,7 +83,7 @@ rules:
     then: 
       function: pattern
       functionOptions:
-        match: "^(\\/|[a-z0-9-.]+|{[a-zA-Z0-9_]+})+$"
+        notMatch: (.+_.)|(\/[a-z]+[A-Z])
 
   # Performance issue with spectral-cli and the regex provided - https://github.com/SPSCommerce/sps-api-standards/issues/26
   # sps-paths-no-special-characters:

--- a/rulesets/src/url-structure.ruleset.yml
+++ b/rulesets/src/url-structure.ruleset.yml
@@ -85,7 +85,7 @@ rules:
       # (.+_.) looks for any instance of an underscore followed by any character
       # (\/[a-z]+[A-Z]) looks for any instance of a forward slash followed by a lowercase character followed by an uppercase character
       functionOptions:
-        notMatch: (\/[a-z]+_.)|(\/[a-z]+[A-Z])
+        notMatch: (\/[a-z]+_.)|(\/([a-z]|[A-Z])+[A-Z])
 
   # Performance issue with spectral-cli and the regex provided - https://github.com/SPSCommerce/sps-api-standards/issues/26
   # sps-paths-no-special-characters:

--- a/rulesets/test/url-structure/sps-paths-kebab-case.test.js
+++ b/rulesets/test/url-structure/sps-paths-kebab-case.test.js
@@ -68,4 +68,54 @@ describe("sps-paths-kebab-case", () => {
        
         await spectral.validateFailure(spec, ruleName, "Error", 1);
     });
+
+    // There was an issue with the previous version of the rule where it would
+    // crash if the none-kebab case was near the end of a long path
+    test("fails with snake case near the end of the path", async () => {
+        const spec = `
+            openapi: 3.1.0
+            paths:
+                /v1/fancy-resource/this-is/a-really-long-path/with-a-fancy_resource/:
+                    get:
+                        summary: hello
+        `;
+       
+        await spectral.validateSuccess(spec, ruleName);
+    });
+
+    test("succeeds with kebab case, but camel case path param", async () => {
+        const spec = `
+            openapi: 3.1.0
+            paths:
+                /v1/fancy-resource/{resourceId}:
+                    get:
+                        summary: hello
+        `;
+       
+        await spectral.validateSuccess(spec, ruleName);
+    });
+
+    test("succeeds with kebab case, but snake case path param", async () => {
+        const spec = `
+            openapi: 3.1.0
+            paths:
+                /v1/fancy-resource/{resource_id}:
+                    get:
+                        summary: hello
+        `;
+       
+        await spectral.validateSuccess(spec, ruleName);
+    });
+
+    test("succeeds with kebab case, but pascal case path param", async () => {
+        const spec = `
+            openapi: 3.1.0
+            paths:
+                /v1/fancy-resource/{ResourceId}:
+                    get:
+                        summary: hello
+        `;
+       
+        await spectral.validateSuccess(spec, ruleName);
+    });
 });


### PR DESCRIPTION
When an instance of camel case, snake case or pascal case occurred near the end of a long path Spectral would lock up and become unresponsive. This was due to the how the Regex was evaluating the whole path for correct casing.

This update flips the check and looks for camel case, snake case and pascal case outside of path params and will fail the rule if it finds even one match. 