### PR TITLE
fix: make sps-ref-property-name more specific

### DIFF
--- a/rulesets/src/naming.ruleset.yml
+++ b/rulesets/src/naming.ruleset.yml
@@ -1,11 +1,10 @@
-rules:   
-
+rules:
   # domain references (URN-like values)
   sps-ref-property-name:
     description: Property with the name 'ref' MUST be of type 'sps-ref' following URN-like reference formats.
     severity: error
     formats: [oas3]
-    given: '$..properties..[?((@property=== "ref" || @property === "Ref") && @.$ref == null && @.allOf == null && @.oneOf == null)]'
+    given: '$..properties..[?((@property=== "ref" || @property === "Ref") && @.$ref == null && @.allOf == null && @.oneOf == null && @.type != null)]'
     resolved: false
     then:
       - field: "format"
@@ -13,17 +12,17 @@ rules:
       - field: "format"
         function: pattern
         functionOptions:
-          match: 'sps-ref'
+          match: "sps-ref"
 
   sps-ref-schema:
     description: Properties following 'sps-ref' format MUST use the standardized schema - maxLength (255), minLength(7), pattern (includes 'sps'), type (string).
-    message: '{{property}} is not provided or not following required schema values.'
+    message: "{{property}} is not provided or not following required schema values."
     severity: error
     formats: [oas3]
     given: '$..[?(@property=== "format" && @ == "sps-ref")]^'
     then:
       - function: schema
-        functionOptions:  
+        functionOptions:
           schema:
             type: object
             required:
@@ -47,23 +46,23 @@ rules:
       - field: pattern
         function: pattern
         functionOptions:
-          match: 'sps'
+          match: "sps"
       - field: type
         function: pattern
         functionOptions:
-          match: '^string$'
+          match: "^string$"
 
   # fingerprint property usage and naming
   sps-fingerprint-naming:
     description: Rather than property names refering to the implementation for 'hash' or 'hashkey', you MUST use the property name 'fingerprint'.
-    message: '{{property}} is not using property name fingerprint.'
+    message: "{{property}} is not using property name fingerprint."
     severity: error
     formats: [oas3]
-    given: '$.components.schemas..properties.*~'
+    given: "$.components.schemas..properties.*~"
     then:
       function: pattern
       functionOptions:
-        notMatch: '^hashkey|hashKey|hash$'
+        notMatch: "^hashkey|hashKey|hash$"
 
   sps-fingerprint-type:
     description: Fingerprint values MUST use a data type of `string`.
@@ -73,4 +72,4 @@ rules:
     then:
       function: pattern
       functionOptions:
-        match: '^string$'
+        match: "^string$"

--- a/rulesets/test/naming/sps-ref-property-name.test.js
+++ b/rulesets/test/naming/sps-ref-property-name.test.js
@@ -27,7 +27,7 @@ describe("sps-ref-property-name", () => {
                         ref: myrefvalue
                         name: hello
         `;
-    
+
         await spectral.validateSuccess(spec, ruleName);
     });
 
@@ -64,5 +64,40 @@ describe("sps-ref-property-name", () => {
                             type: string
         `;
         await spectral.validateFailure(spec, ruleName, "Error");
+    });
+
+    test("Ref property refers to readOnly value, and should pass", async () => {
+        const spec = `
+        openapi: 3.0.1
+        paths:
+            /v1/test:
+                post:
+                    summary: Create a new Rule
+                    requestBody:
+                    required: true
+                    content:
+                        application/json:
+                        schema:
+                            allOf:
+                            - $ref: '#/components/schemas/Rule'
+                            - properties:
+                                ref:
+                                    readOnly: true
+                                priority:
+                                    properties:
+                                    id:
+                                        readOnly: false
+                                    name:
+                                        readOnly: true
+                                type:
+                                    properties:
+                                    id:
+                                        readOnly: false
+                                    name:
+                                        readOnly: true
+                                    ref:
+                                        readOnly: true
+        `;
+        await spectral.validateSuccess(spec, ruleName);
     });
 });


### PR DESCRIPTION
We specifically look to see if there is a "type" field under the ref before we check format