### PR TITLE
DPE 286 collections Rule fix

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,7 +4,8 @@
   // List of extensions which should be recommended for users of this workspace.
   "recommendations": [
     "stoplight.spectral",
-    "redhat.vscode-yaml"
+    "redhat.vscode-yaml",
+    "EditorConfig.EditorConfig"
   ],
   // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
   "unwantedRecommendations": []

--- a/rulesets/src/collections.ruleset.yml
+++ b/rulesets/src/collections.ruleset.yml
@@ -1,17 +1,21 @@
 rules:
   ##### General #####
-  # See https://atlassian.spscommerce.com/browse/DPE-286 
-  # sps-no-collection-paging-capability:
-  #   description: "Response bodies from collection endpoints SHOULD offer paging capability."
-  #   severity: warn
-  #   given: $.paths[?(!@property.match(/.*\/\{[^}]+\}$/))].get.responses['200'].content.application/json.schema.properties
-  #   then:
-  #     - field: "paging"
-  #       function: truthy
-  #     - field: "paging.type"
-  #       function: pattern
-  #       functionOptions:
-  #         match: "object"
+  # See https://atlassian.spscommerce.com/browse/DPE-286
+  sps-no-collection-paging-capability:
+    description: "Response bodies from collection endpoints SHOULD offer paging capability."
+    severity: warn
+    given: $.paths[?(!@property.match(/.*\/\{[^}]+\}.*$/))].get.responses['200'].content.application/json.schema.properties
+    then:
+      - field: "paging"
+        function: truthy
+      - field: "paging"
+        function: pattern
+        functionOptions:
+          match: "object"
+      - field: "paging.type"
+        function: pattern
+        functionOptions:
+          match: "object"
 
   ##### Root Element #####
   sps-collection-missing-results-array:

--- a/rulesets/test/collections/sps-no-collection-paging-capability.test.js
+++ b/rulesets/test/collections/sps-no-collection-paging-capability.test.js
@@ -124,4 +124,28 @@ describe("sps-no-collection-paging-capability", () => {
 
     await spectral.validateFailure(spec, ruleName, "Warning", 1);
   });
+
+  test("valid, response body of a path with ID isn't pageable - invalid path users/{id}/foo", async () => {
+    const spec = `
+    openapi: 3.0.0
+    info:
+      title: Sample API
+      version: 1.0.0
+    paths:
+      /users/{id}/foo:
+        get:
+          summary: Invalid path example
+          responses:
+            '200':
+              description: Invalid path response
+              content:
+                application/json:
+                  schema:
+                    properties:
+                      notACollection:
+                        type: string
+    `;
+
+    await spectral.validateSuccess(spec, ruleName);
+  });
 });

--- a/rulesets/test/collections/sps-no-collection-paging-capability.test.js
+++ b/rulesets/test/collections/sps-no-collection-paging-capability.test.js
@@ -61,7 +61,7 @@ describe("sps-no-collection-paging-capability", () => {
   });
 
   // Re-enable with https://atlassian.spscommerce.com/browse/DPE-286
-  test.skip("invalid - response body - missing paging object", async () => {
+  test("invalid - response body - missing paging object", async () => {
     const spec = `
       openapi: 3.0.0
       info:
@@ -97,7 +97,7 @@ describe("sps-no-collection-paging-capability", () => {
   });
 
   // Re-enable with https://atlassian.spscommerce.com
-  test.skip("invalid - response body - paging element must be an object", async () => {
+  test("invalid - response body - paging element must be an object", async () => {
     const spec = `
     openapi: 3.0.0
     info:


### PR DESCRIPTION
updates the `sps-no-collection-paging-capability` rule to match paths with an ID anywhere in their path 